### PR TITLE
Remove fit_embedding and add n_samples option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,8 @@ finalfusion = { version = "0.17.2", optional = true }
 # https://github.com/rust-lang/rust/issues/113152
 proc-macro2 = "1.0.69"
 
+rand = "0.8.5"
+
 # NOTE(kampersanda): Do not forget to update the version number in `lib.rs` as well.
 wordfreq = { version = "0.2.3", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sif-embedding
 
-<p align="center">
+<p align="left">
   <a href="https://github.com/kampersanda/sif-embedding/actions/workflows/rust.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/kampersanda/sif-embedding/rust.yml?branch=main&style=flat-square" alt="actions status" /></a>
   &nbsp;
   <a href="https://crates.io/crates/sif-embedding"><img src="https://img.shields.io/crates/v/sif-embedding.svg?style=flat-square" alt="Crates.io version" /></a>

--- a/evaluations/jglue/src/main.rs
+++ b/evaluations/jglue/src/main.rs
@@ -152,7 +152,9 @@ fn evaluate<M>(
 where
     M: SentenceEmbedder,
 {
-    let (sent_embeddings, _) = model.fit_embeddings(sentences)?;
+    let model = model.fit(sentences)?;
+    let sent_embeddings = model.embeddings(sentences)?;
+
     let n_examples = gold_scores.len();
     let mut pred_scores = Vec::with_capacity(n_examples);
     for i in 0..n_examples {

--- a/evaluations/senteval/src/main.rs
+++ b/evaluations/senteval/src/main.rs
@@ -222,7 +222,9 @@ fn evaluate<M>(
 where
     M: SentenceEmbedder,
 {
-    let (sent_embeddings, _) = model.fit_embeddings(sentences)?;
+    let model = model.fit(sentences)?;
+    let sent_embeddings = model.embeddings(sentences)?;
+
     let n_examples = gold_scores.len();
     let mut pred_scores = Vec::with_capacity(n_examples);
     for i in 0..n_examples {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub type Float = f32;
 /// Default separator for splitting sentences into words.
 pub const DEFAULT_SEPARATOR: char = ' ';
 
-///
+/// Default number of samples to fit.
 pub const DEFAULT_N_SAMPLES_TO_FIT: usize = 10000;
 
 /// Word embeddings.
@@ -222,15 +222,4 @@ pub trait SentenceEmbedder: Sized {
     where
         I: IntoIterator<Item = S>,
         S: AsRef<str>;
-
-    /// Fits the model with input sentences and computes embeddings using it,
-    /// providing the same behavior as performing [`Self::fit`] and then [`Self::embeddings`].
-    fn fit_embeddings<S>(self, sentences: &[S]) -> Result<(Array2<Float>, Self)>
-    where
-        S: AsRef<str>,
-    {
-        let model = self.fit(sentences)?;
-        let embeddings = model.embeddings(sentences)?;
-        Ok((embeddings, model))
-    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,15 +48,17 @@
 //! // Loads word probabilities from a pretrained model.
 //! let word_probs = WordFreq::new([("las", 0.4), ("vegas", 0.6)]);
 //!
+//! // Prepares input sentences.
+//! let sentences = ["las vegas", "mega vegas"];
+//!
+//! // Fits the model with input sentences.
+//! let model = Sif::new(&word_embeddings, &word_probs);
+//! let model = model.fit(&sentences)?;
+//!
 //! // Computes sentence embeddings in shape (n, m),
 //! // where n is the number of sentences and m is the number of dimensions.
-//! let model = Sif::new(&word_embeddings, &word_probs);
-//! let (sent_embeddings, model) = model.fit_embeddings(&["las vegas", "mega vegas"])?;
+//! let sent_embeddings = model.embeddings(sentences)?;
 //! assert_eq!(sent_embeddings.shape(), &[2, 3]);
-//!
-//! // Once fitted, the parameters can be used to compute sentence embeddings.
-//! let sent_embeddings = model.embeddings(["vegas pro"])?;
-//! assert_eq!(sent_embeddings.shape(), &[1, 3]);
 //! # Ok(())
 //! # }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,9 @@ pub type Float = f32;
 /// Default separator for splitting sentences into words.
 pub const DEFAULT_SEPARATOR: char = ' ';
 
+///
+pub const DEFAULT_N_SAMPLES_TO_FIT: usize = 10000;
+
 /// Word embeddings.
 pub trait WordEmbeddings {
     /// Returns the embedding of a word.

--- a/src/sif.rs
+++ b/src/sif.rs
@@ -324,6 +324,8 @@ where
 
     /// Fits the model with input sentences.
     ///
+    /// Sentences to fit are randomly sampled from `sentences` with [`Self::n_samples_to_fit`].
+    ///
     /// # Errors
     ///
     /// Returns an error if `sentences` is empty.

--- a/src/sif.rs
+++ b/src/sif.rs
@@ -62,15 +62,17 @@ pub const DEFAULT_N_COMPONENTS: usize = 1;
 /// // Loads word probabilities from a pretrained model.
 /// let word_probs = WordFreq::new([("las", 0.4), ("vegas", 0.6)]);
 ///
+/// // Prepares input sentences.
+/// let sentences = ["las vegas", "mega vegas"];
+///
+/// // Fits the model with input sentences.
+/// let model = Sif::new(&word_embeddings, &word_probs);
+/// let model = model.fit(&sentences)?;
+///
 /// // Computes sentence embeddings in shape (n, m),
 /// // where n is the number of sentences and m is the number of dimensions.
-/// let model = Sif::new(&word_embeddings, &word_probs);
-/// let (sent_embeddings, model) = model.fit_embeddings(&["las vegas", "mega vegas"])?;
+/// let sent_embeddings = model.embeddings(sentences)?;
 /// assert_eq!(sent_embeddings.shape(), &[2, 3]);
-///
-/// // Once fitted, the parameters can be used to compute sentence embeddings.
-/// let sent_embeddings = model.embeddings(["vegas pro"])?;
-/// assert_eq!(sent_embeddings.shape(), &[1, 3]);
 /// # Ok(())
 /// # }
 /// ```
@@ -134,15 +136,18 @@ pub const DEFAULT_N_COMPONENTS: usize = 1;
 /// // Loads word probabilities from a pretrained model.
 /// let word_probs = WordFreq::new([("las", 0.4), ("vegas", 0.6)]);
 ///
-/// // Computes sentence embeddings in shape (n, m),
-/// // where n is the number of sentences and m is the number of dimensions.
+/// // Prepares input sentences.
+/// let sentences = ["las vegas", "mega vegas"];
+///
+/// // Fits the model and computes sentence embeddings.
 /// let model = Sif::new(&word_embeddings, &word_probs);
-/// let (sent_embeddings, model) = model.fit_embeddings(&["las vegas", "mega vegas"])?;
+/// let model = model.fit(&sentences)?;
+/// let sent_embeddings = model.embeddings(&sentences)?;
 ///
 /// // Serializes and deserializes the fitted parameters.
 /// let bytes = model.serialize()?;
 /// let other = Sif::deserialize(&bytes, &word_embeddings, &word_probs)?;
-/// let other_embeddings = other.embeddings(["las vegas", "mega vegas"])?;
+/// let other_embeddings = other.embeddings(&sentences)?;
 /// assert_relative_eq!(sent_embeddings, other_embeddings);
 /// # Ok(())
 /// # }

--- a/src/sif.rs
+++ b/src/sif.rs
@@ -40,8 +40,6 @@ pub const DEFAULT_N_COMPONENTS: usize = 1;
 /// [`Sif::fit`] computes the common components from input sentences and returns a fitted instance of [`Sif`].
 /// [`Sif::embeddings`] computes sentence embeddings with the fitted components.
 ///
-/// If you find these two steps annoying, you can use [`Sif::fit_embeddings`].
-///
 /// # Examples
 ///
 /// ```

--- a/src/sif.rs
+++ b/src/sif.rs
@@ -160,6 +160,7 @@ pub struct Sif<'w, 'p, W, P> {
     n_components: usize,
     common_components: Option<Array2<Float>>,
     separator: char,
+    n_samples_to_fit: usize,
 }
 
 impl<'w, 'p, W, P> Sif<'w, 'p, W, P>
@@ -182,6 +183,7 @@ where
             n_components: DEFAULT_N_COMPONENTS,
             common_components: None,
             separator: DEFAULT_SEPARATOR,
+            n_samples_to_fit: DEFAULT_N_SAMPLES_TO_FIT,
         }
     }
 
@@ -215,6 +217,7 @@ where
             n_components,
             common_components: None,
             separator: DEFAULT_SEPARATOR,
+            n_samples_to_fit: DEFAULT_N_SAMPLES_TO_FIT,
         })
     }
 
@@ -222,6 +225,19 @@ where
     pub const fn separator(mut self, separator: char) -> Self {
         self.separator = separator;
         self
+    }
+
+    /// Sets the number of samples to fit the model (default: [`DEFAULT_N_SAMPLES_TO_FIT`]).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `n_samples_to_fit` is 0.
+    pub fn n_samples_to_fit(mut self, n_samples_to_fit: usize) -> Result<Self> {
+        if n_samples_to_fit == 0 {
+            return Err(anyhow!("n_samples_to_fit must not be 0."));
+        }
+        self.n_samples_to_fit = n_samples_to_fit;
+        Ok(self)
     }
 
     /// Applies SIF-weighting.
@@ -263,6 +279,7 @@ where
         bincode::serialize_into(&mut bytes, &self.n_components)?;
         bincode::serialize_into(&mut bytes, &self.common_components)?;
         bincode::serialize_into(&mut bytes, &self.separator)?;
+        bincode::serialize_into(&mut bytes, &self.n_samples_to_fit)?;
         Ok(bytes)
     }
 
@@ -281,6 +298,7 @@ where
         let n_components = bincode::deserialize_from(&mut bytes)?;
         let common_components = bincode::deserialize_from(&mut bytes)?;
         let separator = bincode::deserialize_from(&mut bytes)?;
+        let n_samples_to_fit = bincode::deserialize_from(&mut bytes)?;
         Ok(Self {
             word_embeddings,
             word_probs,
@@ -288,6 +306,7 @@ where
             n_components,
             common_components,
             separator,
+            n_samples_to_fit,
         })
     }
 }
@@ -324,7 +343,7 @@ where
             return Ok(self);
         }
 
-        let sentences = util::sample_sentences(sentences, DEFAULT_N_SAMPLES_TO_FIT);
+        let sentences = util::sample_sentences(sentences, self.n_samples_to_fit);
 
         // SIF-weighting.
         let sent_embeddings = self.weighted_embeddings(sentences);

--- a/src/usif.rs
+++ b/src/usif.rs
@@ -38,8 +38,6 @@ const FLOAT_0_5: Float = 0.5;
 /// [`USif::fit`] computes these values from input sentences and returns a fitted instance of [`USif`].
 /// [`USif::embeddings`] computes sentence embeddings with the fitted values.
 ///
-/// If you find these two steps annoying, you can use [`USif::fit_embeddings`].
-///
 /// # Examples
 ///
 /// ```

--- a/src/usif.rs
+++ b/src/usif.rs
@@ -60,15 +60,17 @@ const FLOAT_0_5: Float = 0.5;
 /// // Loads word probabilities from a pretrained model.
 /// let word_probs = WordFreq::new([("las", 0.4), ("vegas", 0.6)]);
 ///
+/// // Prepares input sentences.
+/// let sentences = ["las vegas", "mega vegas"];
+///
+/// // Fits the model with input sentences.
+/// let model = USif::new(&word_embeddings, &word_probs);
+/// let model = model.fit(&sentences)?;
+///
 /// // Computes sentence embeddings in shape (n, m),
 /// // where n is the number of sentences and m is the number of dimensions.
-/// let model = USif::new(&word_embeddings, &word_probs);
-/// let (sent_embeddings, model) = model.fit_embeddings(&["las vegas", "mega vegas"])?;
+/// let sent_embeddings = model.embeddings(sentences)?;
 /// assert_eq!(sent_embeddings.shape(), &[2, 3]);
-///
-/// // Once fitted, the parameters can be used to compute sentence embeddings.
-/// let sent_embeddings = model.embeddings(["vegas pro"])?;
-/// assert_eq!(sent_embeddings.shape(), &[1, 3]);
 /// # Ok(())
 /// # }
 /// ```
@@ -96,9 +98,13 @@ const FLOAT_0_5: Float = 0.5;
 /// // Loads word probabilities from a pretrained model.
 /// let word_probs = WordFreq::new([("las", 0.4), ("vegas", 0.6)]);
 ///
+/// // Prepares input sentences.
+/// let sentences = ["las vegas", "mega vegas"];
+///
 /// // When setting `n_components` to `0`, no common components are removed.
 /// let model = USif::with_parameters(&word_embeddings, &word_probs, 0);
-/// let (sent_embeddings, _) = model.fit_embeddings(&["las vegas", "mega vegas"])?;
+/// let model = model.fit(&sentences)?;
+/// let sent_embeddings = model.embeddings(sentences)?;
 /// assert_eq!(sent_embeddings.shape(), &[2, 3]);
 /// # Ok(())
 /// # }
@@ -128,15 +134,18 @@ const FLOAT_0_5: Float = 0.5;
 /// // Loads word probabilities from a pretrained model.
 /// let word_probs = WordFreq::new([("las", 0.4), ("vegas", 0.6)]);
 ///
-/// // Computes sentence embeddings in shape (n, m),
-/// // where n is the number of sentences and m is the number of dimensions.
+/// // Prepares input sentences.
+/// let sentences = ["las vegas", "mega vegas"];
+///
+/// // Fits the model and computes sentence embeddings.
 /// let model = USif::new(&word_embeddings, &word_probs);
-/// let (sent_embeddings, model) = model.fit_embeddings(&["las vegas", "mega vegas"])?;
+/// let model = model.fit(&sentences)?;
+/// let sent_embeddings = model.embeddings(&sentences)?;
 ///
 /// // Serializes and deserializes the fitted parameters.
 /// let bytes = model.serialize()?;
 /// let other = USif::deserialize(&bytes, &word_embeddings, &word_probs)?;
-/// let other_embeddings = other.embeddings(["las vegas", "mega vegas"])?;
+/// let other_embeddings = other.embeddings(&sentences)?;
 /// assert_relative_eq!(sent_embeddings, other_embeddings);
 /// # Ok(())
 /// # }

--- a/src/usif.rs
+++ b/src/usif.rs
@@ -8,6 +8,7 @@ use crate::Float;
 use crate::SentenceEmbedder;
 use crate::WordEmbeddings;
 use crate::WordProbabilities;
+use crate::DEFAULT_N_SAMPLES_TO_FIT;
 use crate::DEFAULT_SEPARATOR;
 
 /// Default value of the number of principal components,
@@ -372,8 +373,11 @@ where
         if sentences.is_empty() {
             return Err(anyhow!("Input sentences must not be empty."));
         }
+
+        let sentences = util::sample_sentences(sentences, DEFAULT_N_SAMPLES_TO_FIT);
+
         // SIF-weighting.
-        let sent_len = self.average_sentence_length(sentences);
+        let sent_len = self.average_sentence_length(&sentences);
         if sent_len == 0. {
             return Err(anyhow!("Input sentences must not be empty."));
         }

--- a/src/usif.rs
+++ b/src/usif.rs
@@ -384,6 +384,7 @@ where
         let param_a = self.estimate_param_a(sent_len);
         let sent_embeddings = self.weighted_embeddings(sentences, param_a);
         self.param_a = Some(param_a);
+
         // Common component removal.
         if self.n_components != 0 {
             let (weights, common_components) = self.estimate_principal_components(&sent_embeddings);
@@ -392,6 +393,7 @@ where
         }
         // NOTE: There is no need to set weights and common_components to None.
         //       because n_components can be set up only in initialization.
+
         Ok(self)
     }
 
@@ -422,42 +424,6 @@ where
         let sent_embeddings =
             util::remove_principal_components(&sent_embeddings, common_components, Some(weights));
         Ok(sent_embeddings)
-    }
-
-    /// Fits the model with input sentences and computes embeddings using it,
-    /// providing the same behavior as performing [`Self::fit`] and then [`Self::embeddings`].
-    fn fit_embeddings<S>(mut self, sentences: &[S]) -> Result<(Array2<Float>, Self)>
-    where
-        S: AsRef<str>,
-    {
-        if sentences.is_empty() {
-            return Err(anyhow!("Input sentences must not be empty."));
-        }
-        // SIF-weighting.
-        let sent_len = self.average_sentence_length(sentences);
-        if sent_len == 0. {
-            return Err(anyhow!("Input sentences must not be empty."));
-        }
-        let param_a = self.estimate_param_a(sent_len);
-        let sent_embeddings = self.weighted_embeddings(sentences, param_a);
-        self.param_a = Some(param_a);
-        // Common component removal.
-        let sent_embeddings = if self.n_components != 0 {
-            let (weights, common_components) = self.estimate_principal_components(&sent_embeddings);
-            let sent_embeddings = util::remove_principal_components(
-                &sent_embeddings,
-                &common_components,
-                Some(&weights),
-            );
-            self.weights = Some(weights);
-            self.common_components = Some(common_components);
-            sent_embeddings
-        } else {
-            // NOTE: There is no need to set weights and common_components to None.
-            //       because n_components can be set up only in initialization.
-            sent_embeddings
-        };
-        Ok((sent_embeddings, self))
     }
 }
 

--- a/src/usif.rs
+++ b/src/usif.rs
@@ -391,6 +391,8 @@ where
 
     /// Fits the model with input sentences.
     ///
+    /// Sentences to fit are randomly sampled from `sentences` with [`Self::n_samples_to_fit`].
+    ///
     /// # Errors
     ///
     /// Returns an error if `sentences` is empty.

--- a/src/util.rs
+++ b/src/util.rs
@@ -93,6 +93,19 @@ where
     vectors.to_owned() - &projection
 }
 
+pub(crate) fn sample_sentences<'a, S>(sentences: &'a [S], sample_size: usize) -> Vec<&'a str>
+where
+    S: AsRef<str> + 'a,
+{
+    let n_sentences = sentences.len();
+    if n_sentences <= sample_size {
+        sentences.iter().map(|s| s.as_ref()).collect()
+    } else {
+        let indices = rand::seq::index::sample(&mut rand::thread_rng(), n_sentences, sample_size);
+        indices.into_iter().map(|i| sentences[i].as_ref()).collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,5 +218,14 @@ mod tests {
         let weights = ndarray::arr1(&[1.]);
         let result = remove_principal_components(&vectors, &components, Some(&weights));
         assert_eq!(result.shape(), &[3, 1]);
+    }
+
+    #[test]
+    fn test_sample_sentences() {
+        let sentences = vec!["a", "b", "c", "d", "e", "f", "g"];
+        let sample_size = 3;
+        let sampled = sample_sentences(&sentences, sample_size);
+        assert_eq!(sampled.len(), sample_size);
+        assert!(sampled.iter().all(|s| sentences.contains(s)));
     }
 }

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -110,7 +110,8 @@ let sentences = vec![
     "This is a third sentence.",
 ];
 let model = Sif::new(&word_embeddings, &word_probs);
-let (sent_embeddings, model) = model.fit_embeddings(&sentences)?;
+let model = model.fit(&sentences)?;
+let sent_embeddings = model.embeddings(sentences)?;
 println!("{:?}", sent_embeddings);
 ```
 

--- a/tutorial/src/main.rs
+++ b/tutorial/src/main.rs
@@ -45,10 +45,13 @@ fn main() -> Result<(), Box<dyn Error>> {
         "This is a third sentence.",
     ];
 
+    // Fits the model with input sentences.
+    let model = Sif::new(&word_embeddings, &word_probs);
+    let model = model.fit(&sentences)?;
+
     // Computes sentence embeddings in shape (n, m),
     // where n is the number of sentences and m is the number of dimensions.
-    let model = Sif::new(&word_embeddings, &word_probs);
-    let (sent_embeddings, model) = model.fit_embeddings(&sentences)?;
+    let sent_embeddings = model.embeddings(sentences)?;
     println!("{:?}", sent_embeddings);
 
     // Prepare new input sentences.


### PR DESCRIPTION
- Add n_samples_to_fit() option to avoid using an unintended large training corpus.
- Remove fit_embedding option to avoid misunderstanding of pipeline for fit and embedding.